### PR TITLE
feat:(UA-9616): Support purchases per country daily metric

### DIFF
--- a/src/AnimatedGlobe.tsx
+++ b/src/AnimatedGlobe.tsx
@@ -57,7 +57,15 @@ interface AnimatedGlobeProps {
 }
 
 // Normalize the response until the lambda is updated everywhere.
-const normalizeResponse = (response: RealTimeMetricsResponse | LiveEvent[]) => Array.isArray(response) ? response : response.items;
+const normalizeResponse = (response: RealTimeMetricsResponse | LiveEvent[] | {message: string}): LiveEvent[] => {
+    if (Array.isArray(response)) {
+      return response;
+    }
+    if ("message" in response) {
+      throw new Error(response.message);
+    }
+    return response.items;
+};
 
 export const AnimatedGlobe: FunctionComponent<AnimatedGlobeProps> = ({
   renderRings,

--- a/src/AnimatedGlobe.tsx
+++ b/src/AnimatedGlobe.tsx
@@ -7,6 +7,7 @@ import {
   envRegionMapping,
   LiveEvent,
   CoveoEnvironment,
+  RealTimeMetricsResponse,
 } from "./Events";
 import { uniqBy } from "lodash";
 import * as THREE from "three";
@@ -55,6 +56,9 @@ interface AnimatedGlobeProps {
   env: CoveoEnvironment;
 }
 
+// Normalize the response until the lambda is updated everywhere.
+const normalizeResponse = (response: RealTimeMetricsResponse | LiveEvent[]) => Array.isArray(response) ? response : response.items;
+
 export const AnimatedGlobe: FunctionComponent<AnimatedGlobeProps> = ({
   renderRings,
   renderArcs,
@@ -83,9 +87,9 @@ export const AnimatedGlobe: FunctionComponent<AnimatedGlobeProps> = ({
   const emitArc = async () => {
     const resTotal = new Map<ValidRegions, LiveEvent[]>();
     for (const regionConfig of envRegionMapping[env]) {
-      const liveEventFetcher: LiveEvent[] = (await (
+      const liveEventFetcher: LiveEvent[] = normalizeResponse(await (
         await fetch(`${regionConfig.lambdaEndpoint}&last=${tickSpeed}`)
-      ).json()) as LiveEvent[];
+      ).json());
       resTotal.set(regionConfig.region, liveEventFetcher);
     }
 

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -1,11 +1,13 @@
 export type CoveoEnvironment = "dev" | "stg" | "prd";
 export const isCoveoEnvironment = (value: unknown): value is CoveoEnvironment =>
-    typeof value === 'string' && /dev|stg|prod/.test(value);
+    typeof value === 'string' && /dev|stg|prd/.test(value);
 
 export const normalizeCoveoEnvironment = (value: unknown): CoveoEnvironment =>
     isCoveoEnvironment(value) ? value : 'prd';
 
 export type ValidRegions = "us-east-1" | "us-east-2" | "eu-west-1" | "ap-southeast-2" | "ca-central-1";
+
+export type MetricType = 'real-time' | 'minutely' | 'daily';
 
 export interface LiveEvent {
     city: string;
@@ -22,10 +24,37 @@ export interface LiveEvent {
     price?: string | number;
 }
 
-export interface TimeBucketMetric {
-    type: string;
-    timeBucketType: string;
-    count: string;
+export interface MetricsResponse {
+    type: MetricType;
+}
+
+export interface RealTimeMetricsResponse extends MetricsResponse {
+    type: 'real-time';
+    items: LiveEvent[];
+}
+
+export interface CommonMetrics {
+    addToCart: number;
+    purchases: number;
+    revenue: number;
+}
+
+export interface DailyMetrics extends CommonMetrics {
+    purchasesPerCountry: Record<string, number>;
+}
+
+export interface MinutelyMetrics extends CommonMetrics {
+    uniqueUsers: number;
+}
+
+export interface DailyMetricsResponse extends MetricsResponse {
+    type: 'daily';
+    metrics: Partial<DailyMetrics>;
+}
+
+export interface MinutelyMetricsResponse extends MetricsResponse {
+    type: 'minutely';
+    metrics: Partial<MinutelyMetrics>;
 }
 
 export const AWSRegionGeo = Object.freeze({

--- a/src/GlobeAndPanel.tsx
+++ b/src/GlobeAndPanel.tsx
@@ -119,7 +119,7 @@ export const GlobeAndPanel: FunctionComponent = () => {
           <Image src={"coveo.png"} style={{ width: "50px" }} />
         </Grid.Col>
         <Grid.Col span={6} style={{ borderLeft: "2px solid white" }}>
-          <Text>bfcm'24</Text>
+          <Text>bfcm'{new Date().getUTCFullYear().toString().substring(2)}</Text>
         </Grid.Col>
       </Grid>
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,93 @@
+import { DailyMetrics, MinutelyMetrics } from "./Events";
+
+const MILLIS_IN_DAY = 24 * 3600000;
+/** Cache for calculated holidays. */
+const CACHE = new Map<string, Readonly<Date>>();
+
+/**
+ * Utility to create a cached calculated holiday resolver.
+ *
+ * @param suffix The cache suffix, must be unique for all cached calculated holidays.
+ * @param calculate The method that calculates the day.
+ * @returns The Date representing the holiday.
+ */
+const cached = (suffix: string, calculate: (year: number) => Date): (year: number) => Readonly<Date> =>
+    (year: number) => {
+        const k = `${year}-${suffix}`;
+        let v = CACHE.get(k);
+        if (!v) {
+            v = Object.freeze(calculate(year));
+            CACHE.set(k, v);
+        }
+        return v;
+    };
+
+/**
+ * Add a number of days to a Date, returning a new Date with the result.
+ *
+ * @param date 
+ * @param days 
+ * @returns 
+ */
+export const plusDays = (date: Readonly<Date>, days: number): Date =>
+    new Date(date.getTime() + (days * MILLIS_IN_DAY));
+
+/**
+ * Calculate the number of full days between two dates, not taking into account DST.
+ * If the value is before the anchor, the difference will be negative.
+ *
+ * @param anchor The date to calculate relative to.
+ * @param value The value to compare to.
+ * @returns The number of full (24 hour) days.
+ */
+export const dayDiff = (anchor: Readonly<Date>, value: Readonly<Date>): number =>
+    Math.floor((value.getTime() - anchor.getTime()) / MILLIS_IN_DAY);
+
+/**
+ * Calculate the day (United States) Thanksgiving falls on in a year.
+ *
+ * @param year The year.
+ * @returns The UTC midnight of Thanksgiving day.
+ */
+export const thanksgivingUS = cached('tg', (year: number): Date => {
+    // Start on the first of November
+    const day = new Date(Date.UTC(year, 10, 1));
+    // Shift to the 4th Thursday of the month
+    day.setUTCDate((11 - day.getUTCDay()) % 7 + 22);
+    return day;
+});
+
+/**
+ * Calculate the day Black Friday falls on in a year.
+ *
+ * @param year The year.
+ * @returns The UTC midnight of Black Friday.
+ */
+export const blackFriday = cached('bf', (year: number): Date => {
+    return plusDays(thanksgivingUS(year), 1);
+});
+
+export const emptyDaily = (): DailyMetrics => ({addToCart: 0, purchases: 0, revenue: 0, purchasesPerCountry: {}});
+export const emptyMinutely = (): MinutelyMetrics => ({addToCart: 0, purchases: 0, revenue: 0, uniqueUsers: 0});
+
+export const aggregateMinutely = (minutelyMetricsPerRegion: ReadonlyArray<Partial<MinutelyMetrics>>): MinutelyMetrics =>
+    minutelyMetricsPerRegion.reduce((acc: MinutelyMetrics, metrics) => {
+        acc.addToCart += metrics.addToCart ?? 0;
+        acc.purchases += metrics.purchases ?? 0;
+        acc.revenue += metrics.revenue ?? 0;
+        acc.uniqueUsers += metrics.uniqueUsers ?? 0;
+        return acc;
+    }, emptyMinutely());
+
+export const aggregateDaily = (dailyMetricsPerRegion: ReadonlyArray<Partial<DailyMetrics>>): DailyMetrics =>
+    dailyMetricsPerRegion.reduce((acc: DailyMetrics, metrics) => {
+        acc.addToCart += metrics.addToCart ?? 0;
+        acc.purchases += metrics.purchases ?? 0;
+        acc.revenue += metrics.revenue ?? 0;
+        if (metrics.purchasesPerCountry) {
+            for (const key of Object.keys(metrics.purchasesPerCountry)) {
+                acc.purchasesPerCountry[key] = (acc.purchasesPerCountry[key] ?? 0) + metrics.purchasesPerCountry[key];
+            }
+        }
+        return acc;
+    }, emptyDaily());


### PR DESCRIPTION
## [UA-9616](https://coveord.atlassian.net/browse/UA-9616) :rocket:

### Proposed changes:
After @mpayne-coveo introduced "purchases per country" tracked as a client-side metric (lost on page refresh), people asked if it could be made into a proper metric. The core of the changes is to apply that, but it comes with a bunch of other changes. The most important thing is that the protocol has been changed.

<details><summary>Protocol change example</summary>
<p>

Before:

```json
[
    {
        "type": "purchases",
        "timeBucketType": "daily",
        "count": 15430
    },
    {
        "type": "addToCart",
        "timeBucketType": "daily",
        "count": 32098
    },
    {
        "type": "revenue",
        "timeBucketType": "daily",
        "count": 341002
    }
]
```

After:

```json
{
    "type": "daily",
    "metrics":
    {
        "addToCart": 1,
        "purchases": 2,
        "revenue": 3.45,
        "purchasesPerCountry": {
            "CA": 3,
            "GB": 2,
            "NL": 1
        }
    }
}
```

</p>
</details>

The most important reason for that change is that the metrics up to now put a numeric value in a "count" property, but this was awkward for purchasesPerCountry, which is a "map". The array format also makes no sense: it cost the reader lambda effort to build it while it actually got the object form, and the client had to iterate the array and basically rebuild the metrics object (although it smeared it out in separate number state fields).

Besides the protocol change, I refactored the code to simplify it, to hard-code less, and to fix issues:
  - Calculate Black Friday based on the current year (in UTC)
  - Do time calculations in **UTC**.
  - Simplify the number of states tracked, by using objects instead of separate numbers (that are basically fields).
  - Introduce `normalizeResponse` methods that support both versions of the protocol for now.
    This can be removed as soon as the PR in SSES is merged and deployed everywhere.

An important building block is the utilities that aggregate metrics. This is used in two fashions:
 1. To aggregate across regions
 2. During Black Friday/Cyber Monday, to aggregate the revenue with previous days.
    (Technically it aggregates all metrics, we just only show revenue across days).

### How to test

The sad part: you will only see the Purchases per country, once the metric is actually in DynamoDB. I deployed a development version on dev us-east-1 on the day I created this PR (2024-12-13), but this may be replaced by any other deployment in that region. While this custom version is active, you will see purchases per country in the dev environment (for us-east-1 only).

What _is_ important, is that the rest of the metrics do work for all other environments and regions, which shows you that the compatibility code patches the data to the new format. Since this page can handle both types of responses, it would be best to merge and deploy this before merging and deploying the changes to SSES (which "breaks" the protocol for older versions of the globe).


[UA-9616]: https://coveord.atlassian.net/browse/UA-9616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ